### PR TITLE
Add transform resolver for ApiVideoUploaderApiVideoAssetEntity

### DIFF
--- a/src/server/register.ts
+++ b/src/server/register.ts
@@ -1,4 +1,5 @@
 import { findOneWithPrivateVideoTransform, findWithPrivateVideoTransform } from "./controllers/content-api-controller";
+import { replacePrivateVideoTokens } from "./utils/private-videos";
 
 
 const toEntityResponse = (entity: any) => strapi.service("plugin::graphql.format").returnTypes.toEntityResponse(entity);
@@ -14,6 +15,11 @@ export default async ({ strapi }: { strapi: any }) => {
     
     extensionService.use({
         resolvers: {
+            ApiVideoUploaderApiVideoAssetEntity: {
+                attributes: {
+                    resolve: async (parent: any, args: any, context: any, info: any) => replacePrivateVideoTokens(parent)
+                }
+            },
             Query: {
                 apiVideoUploaderApiVideoAsset: {
                     resolve: async (parent: any, args: any, context: any, info: any) => toEntityResponse(findOneWithPrivateVideoTransform(args.id))

--- a/src/server/register.ts
+++ b/src/server/register.ts
@@ -1,10 +1,4 @@
-import { findOneWithPrivateVideoTransform, findWithPrivateVideoTransform } from "./controllers/content-api-controller";
 import { replacePrivateVideoTokens } from "./utils/private-videos";
-
-
-const toEntityResponse = (entity: any) => strapi.service("plugin::graphql.format").returnTypes.toEntityResponse(entity);
-const toEntityResponseCollection = (entity: any) => strapi.service("plugin::graphql.format").returnTypes.toEntityResponseCollection(entity);
-
 
 export default async ({ strapi }: { strapi: any }) => {
     const extensionService = strapi.plugin('graphql').service('extension');
@@ -20,14 +14,6 @@ export default async ({ strapi }: { strapi: any }) => {
                     resolve: async (parent: any, args: any, context: any, info: any) => replacePrivateVideoTokens(parent)
                 }
             },
-            Query: {
-                apiVideoUploaderApiVideoAsset: {
-                    resolve: async (parent: any, args: any, context: any, info: any) => toEntityResponse(findOneWithPrivateVideoTransform(args.id))
-                },
-                apiVideoUploaderApiVideoAssets: {
-                    resolve: async (parent: any, args: any, context: any, info: any) => toEntityResponseCollection(await findWithPrivateVideoTransform())
-                }
-            }
         }
     })
   };


### PR DESCRIPTION
This changes the GraphQL resolver of the `ApiVideoUploaderApiVideoAssetEntity` to replace the dummy tokens with actual private tokens. This will work in the general case where we query `Query.apiVideoUploaderApiAssets` and in the case where we include the API Video asset as a relation in other Strapi entities, solving the GraphQL issue in #14.